### PR TITLE
feat: add `appearance` deprecate `ondark` #90

### DIFF
--- a/apiExamples/billboardSeries.html
+++ b/apiExamples/billboardSeries.html
@@ -1,4 +1,4 @@
-<auro-banner billboard slim alignRight ondark>
+<auro-banner billboard slim alignRight appearance="inverse">
   <picture slot="displayImage">
     <source srcset="https://picsum.photos/id/324/1124/800" media="(min-width: 1024px)">
     <source srcset="https://picsum.photos/id/324/1124/1000" media="(min-width: 768px)">
@@ -7,13 +7,13 @@
     <source srcset="https://picsum.photos/id/324/320/700" media="(min-width: 320px)">
     <img src="https://picsum.photos/id/324/225/550" alt="" />
   </picture>
-  <auro-alaska official ondark style="width: 192px" slot="contentImage"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px" slot="contentImage"></auro-alaska>
   <p slot="description">
     <span style="max-width:320px; margin-left:auto; display:block">Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</span>
   </p>
   <auro-hyperlink
     cta
-    ondark
+    appearance="inverse"
     href="/"
     slot="action"
     target="_blank">

--- a/apiExamples/billboardSeriesLeft.html
+++ b/apiExamples/billboardSeriesLeft.html
@@ -1,4 +1,4 @@
-<auro-banner billboard slim alignLeft onDark>
+<auro-banner billboard slim alignLeft appearance="inverse">
   <picture slot="displayImage">
     <source srcset="https://picsum.photos/id/42/1124/800" media="(min-width: 1024px)">
     <source srcset="https://picsum.photos/id/42/1124/1000" media="(min-width: 768px)">
@@ -14,7 +14,7 @@
   <auro-hyperlink
     cta
     secondary
-    ondark
+    appearance="inverse"
     href="/"
     slot="action"
     target="_blank">

--- a/apiExamples/marqueeSolid.html
+++ b/apiExamples/marqueeSolid.html
@@ -4,13 +4,13 @@
     <source srcset="https://picsum.photos/id/1015/736/1400" media="(min-width:660px)">
     <img src="https://picsum.photos/id/1015/660/660" alt="">
   </picture>
-  <auro-alaska official ondark style="width: 192px" slot="contentImage"></auro-alaska>
+  <auro-alaska official appearance="inverse" style="width: 192px" slot="contentImage"></auro-alaska>
   <p slot="description">
     Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
   </p>
   <auro-hyperlink
     cta
-    ondark
+    appearance="inverse"
     href="/"
     slot="action"
     target="_blank">

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,19 +9,20 @@ The auro-banner element provides users a flexible way to convey a summary of inf
 | `alignLeft`  | `Boolean` | to be used when we want the text aligned to the left |
 | `alignRight` | `Boolean` | to be used when we want the text aligned to the right |
 | `billboard`  | `Boolean` | to be used for billboard style configuration     |
-| `onDark`     | `Boolean` | to be used when the background image or color is dark and changes the text and cta color |
+| `onDark`     | `Boolean` | DEPRECATED - use `appearance="inverse"` instead. |
 | `slim`       | `Boolean` | to be used when we want a slimmer padding to the default banner |
 | `solid`      | `Boolean` | to be used when you want a solid color as opposed to a transparent background |
 
 ## Properties
 
-| Property        | Attribute       | Type      | Default | Description                                      |
-|-----------------|-----------------|-----------|---------|--------------------------------------------------|
-| `hero`          | `hero`          | `Boolean` | false   | to be used for hero style configuration          |
-| `iconbg`        | `iconbg`        | `String`  |         | to be used in conjunction with the iconic variant this specifies the background color of the icon |
-| `iconic`        | `iconic`        | `Boolean` | false   | to be used in as a hero on pages but with an icon and no displayImage on mobile |
-| `marquee`       | `marquee`       | `Boolean` | false   | to be used for marquee style configuration       |
-| `roundedBorder` | `roundedBorder` | `Boolean` | false   | to be used for roundedBorder style configuration |
+| Property        | Attribute       | Type      | Default     | Description                                      |
+|-----------------|-----------------|-----------|-------------|--------------------------------------------------|
+| `appearance`    | `appearance`    | `string`  | "'default'" | Defines whether the component will be on lighter or darker backgrounds. |
+| `hero`          | `hero`          | `Boolean` | false       | to be used for hero style configuration          |
+| `iconbg`        | `iconbg`        | `String`  |             | to be used in conjunction with the iconic variant this specifies the background color of the icon |
+| `iconic`        | `iconic`        | `Boolean` | false       | to be used in as a hero on pages but with an icon and no displayImage on mobile |
+| `marquee`       | `marquee`       | `Boolean` | false       | to be used for marquee style configuration       |
+| `roundedBorder` | `roundedBorder` | `Boolean` | false       | to be used for roundedBorder style configuration |
 
 ## Slots
 

--- a/docs/partials/api.md
+++ b/docs/partials/api.md
@@ -38,11 +38,11 @@ By default `<img>` elements are `inline` elements and will add a few pixels of s
 
 </auro-accordion>
 
-#### Billboard / slim / alignRight / onDark
+#### Billboard / slim / alignRight / appearance
 
 The following example illustrates a series of additional API options available to the `<auro-banner>` element. In this example, this shows how a user can augment the `billboard` theme of the `<auro-banner>`.
 
-For the call-to-action button, see in the example code that it is required to set the `onDark` attribute on the `<auro-hyperlink>` element itself. This is **not** controlled by the `<auro-banner>` element.
+For the call-to-action button, see in the example code that it is required to set the `appearance="inverse"` attribute on the `<auro-hyperlink>` element itself. This is **not** controlled by the `<auro-banner>` element.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/billboardSeries.html) -->
@@ -57,9 +57,9 @@ For the call-to-action button, see in the example code that it is required to se
 
 </auro-accordion>
 
-#### Billboard / slim / alignLeft / onDark
+#### Billboard / slim / alignLeft / appearance
 
-The following example illustrates an option to left align the text `alignLeft` along with `slim` to reduce the padding and `onDark` to change the text to white.
+The following example illustrates an option to left align the text `alignLeft` along with `slim` to reduce the padding and `appearance="inverse"` to change the text to white.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/billboardSeriesLeft.html) -->
@@ -110,7 +110,7 @@ The following example illustrates a `<auro-banner>` custom element with the `ico
 
 ### Marquee
 
-The following example illustrates a `<auro-banner>` custom element with the `marquee` template style. This template configuration also supports the `slim` and `onDark` attributes.
+The following example illustrates a `<auro-banner>` custom element with the `marquee` template style. This template configuration also supports the `slim` and `appearance="inverse"` attributes.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/marquee.html) -->
@@ -127,7 +127,7 @@ The following example illustrates a `<auro-banner>` custom element with the `mar
 
 ### Marquee / solid
 
-The following example illustrates a `<auro-banner>` custom element with the `marquee solid` template style. With this configuration, onDark is implied.
+The following example illustrates a `<auro-banner>` custom element with the `marquee solid` template style. With this configuration, `appearance="inverse"` is implied.
 
 <div class="exampleWrapper">
   <!-- AURO-GENERATED-CONTENT:START (FILE:src=../apiExamples/marqueeSolid.html) -->

--- a/src/auro-banner.js
+++ b/src/auro-banner.js
@@ -29,7 +29,7 @@ import tokensCss from "./styles/tokens.scss";
  * @attr {Boolean} slim - to be used when we want a slimmer padding to the default banner
  * @attr {Boolean} alignRight - to be used when we want the text aligned to the right
  * @attr {Boolean} alignLeft - to be used when we want the text aligned to the left
- * @attr {Boolean} onDark - to be used when the background image or color is dark and changes the text and cta color
+ * @attr {Boolean} onDark - DEPRECATED - use `appearance="inverse"` instead.
  * @slot displayImage - placement for `<picture />` or `<img>` elements
  * @slot prefix - placement for smaller text above title
  * @slot title - placement for header
@@ -41,6 +41,8 @@ import tokensCss from "./styles/tokens.scss";
 export class AuroBanner extends LitElement {
   constructor() {
     super();
+
+    this.appearance = "default";
     this.hero = false;
     this.iconic = false;
     this.marquee = false;
@@ -93,6 +95,17 @@ export class AuroBanner extends LitElement {
   static get properties() {
     return {
       ...LitElement.properties,
+
+      /**
+       * Defines whether the component will be on lighter or darker backgrounds.
+       * @property {'default', 'inverse'}
+       * @default 'default'
+       */
+      appearance: {
+        type: String,
+        reflect: true
+      },
+
       hero: {
         type: Boolean,
         reflect: true,

--- a/src/styles/color.scss
+++ b/src/styles/color.scss
@@ -36,7 +36,8 @@
   }
 }
 
-:host([onDark]) {
+:host([onDark]),
+:host([appearance="inverse"]) {
   @extend %auro-banner--ondark;
 }
 


### PR DESCRIPTION
# Alaska Airlines Pull Request

Close #90 

This is to replace `onDark` attr with `appearance` attr. 
- Adding `appearance` with its default value `default`
- Mark `onDark` as deprecated in the api table
- Replace `onDark` with `appearance="inverse"` in all examples 

## Checklist:

- [x] My update follows the CONTRIBUTING guidelines of this project
- [x] I have performed a self-review of my own update

**By submitting this Pull Request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

_Pull Requests will be evaluated by their quality of update and whether it is consistent with the goals and values of this project. Any submission is to be considered a conversation between the submitter and the maintainers of this project and may require changes to your submission._

**Thank you for your submission!**<br>
-- Auro Design System Team
